### PR TITLE
Remove submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ jspm_packages
 .node_repl_history
 
 .git-credentials
+dist/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dist"]
-	path = dist
-	url = https://github.com/trajano/trajano-portfolio
-	branch = gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ before_install:
 - git config --global credential.helper store
 - git config --global user.email "travis@trajano.net"
 - git config --global user.name  "Travis Service Account"
+- git clone https://github.com/trajano/trajano-portfolio.git -b gh-pages --depth 1 dist
+- git -C dist rm -rf .
 after_success:
-- git -C dist add -A
+- git -C dist add .
 - git -C dist commit -a -m "Travis build"
-- git -C dist rebase origin/gh-pages
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git -C dist push origin HEAD:gh-pages; fi


### PR DESCRIPTION
Instead of using submodule updates, a new clone is created with depth=1 for the gh-pages branch.  This allows it to download quickly as the whole history is not needed.

The data is wiped and a new version is created with the normal scripts. The new version will then be commuted and eventually pushed in.